### PR TITLE
fix: make array query params work with default swagger mode

### DIFF
--- a/src/main/java/io/gravitee/entrypoint/mcp/service/MCPHandler.java
+++ b/src/main/java/io/gravitee/entrypoint/mcp/service/MCPHandler.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -178,7 +179,15 @@ public class MCPHandler {
             .getQueryParams()
             .stream()
             .filter(arguments::containsKey)
-            .map(s -> s + "=" + arguments.get(s).toString())
+            .flatMap(arg -> {
+                // Note: We support only default swagger query serialization method e.g. ?arg=value1&arg=value2
+                // To change this behavior, we need to improve GatewayMapping to support more complex query serialization methods from imported Swagger spec
+                // Link: https://swagger.io/docs/specification/v3_0/serialization/#query-parameters
+                if (arguments.get(arg) instanceof List<?> values) {
+                    return values.stream().map(value -> arg + "=" + value.toString());
+                }
+                return Stream.of(arg + "=" + arguments.get(arg).toString());
+            })
             .reduce((s, s2) -> s + "&" + s2);
         if (queryParams.isPresent()) {
             path = path + "?" + queryParams.get();

--- a/src/test/java/io/gravitee/entrypoint/mcp/service/MCPHandlerTest.java
+++ b/src/test/java/io/gravitee/entrypoint/mcp/service/MCPHandlerTest.java
@@ -98,7 +98,7 @@ class MCPHandlerTest {
                                 .contentType("application/json")
                                 .headers(List.of("X-My-Header"))
                                 .pathParams(List.of("myPathParam", "anotherParam"))
-                                .queryParams(List.of("myQueryParam", "myQueryParam2"))
+                                .queryParams(List.of("myQueryParam", "myQueryParam2", "myQueryParam3"))
                                 .build()
                         )
                         .build()
@@ -271,6 +271,8 @@ class MCPHandlerTest {
                       "myPathParam": "pathParam1",
                       "anotherParam": "pathParam2",
                       "myQueryParam": "queryValue",
+                      "myQueryParam2": ["value1", "value2"],
+                      "myQueryParam3": [],
                       "bodySchema": {
                         "type": "string"
                       }
@@ -295,7 +297,7 @@ class MCPHandlerTest {
             assertThat(requestHeaders.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("application/json");
             assertThat(requestHeaders.get(HttpHeaderNames.ACCEPT)).isEqualTo("application/json");
             verify(request).method(HttpMethod.POST);
-            verify(request).pathInfo("/foo/pathParam1/bar/pathParam2?myQueryParam=queryValue");
+            verify(request).pathInfo("/foo/pathParam1/bar/pathParam2?myQueryParam=queryValue&myQueryParam2=value1&myQueryParam2=value2");
             verify(request).body(argThat(buffer -> buffer.toString().equals("{\"type\":\"string\"}")));
         }
 


### PR DESCRIPTION
**Issue**


**Description**

make array query params work with default swagger mode

https://swagger.io/docs/specification/v3_0/serialization/#query-parameters

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

